### PR TITLE
Logic to Allow Snake to Enter Tail

### DIFF
--- a/snake/snake.go
+++ b/snake/snake.go
@@ -69,8 +69,9 @@ func stopHittingYourself(you datatypes.Battlesnake, avaliableDirections []dataty
 	var excludedDirections []datatypes.Direction
 	for _, dir := range avaliableDirections {
 		nextCoord := datatypes.AddDirectionToCoord(you.Head, dir)
+		tail := you.Body[you.Length-1]
 		for _, bodyCoord := range you.Body {
-			if nextCoord == bodyCoord {
+			if nextCoord == bodyCoord && nextCoord != tail{
 				excludedDirections = append(excludedDirections, dir)
 				break
 			}


### PR DESCRIPTION
Added logic to allow the snake to attempt to enter the box where the tail is. This is because the next turn the tail will no longer be there.